### PR TITLE
Update SRParasitesSystems.cfg

### DIFF
--- a/config/srparasites/SRParasitesSystems.cfg
+++ b/config/srparasites/SRParasitesSystems.cfg
@@ -454,7 +454,7 @@ parasite_evolution_phases {
     I:"Default Points Start"=-1000
 
     # Set to false if you want to use Vanilla Spawner (parasite mob cap will not work if set to false). [default: true]
-    B:"Evolution Custom Spawner"=false
+    B:"Evolution Custom Spawner"=true
 
     # True if parasites can gain points when there are no players in the server. [default: false]
     B:"Evolution No Players Gaining"=false
@@ -590,10 +590,10 @@ parasite_evolution_phases {
     #  "10" is the number of points parasites will have, if the phase is -1 these points will be negative (Set the points above 0 if the phase is -1 or -2)
     #  Parasites will not spawn and can't earn points if the phase is -2 [default: [-1;-1;50], [0;0;0], [1;-1;100], [270;-1;300]]
     S:"Evolution Phases Dimension Starting Phase List" <
-        -1;-1;50
-        0;-1;-1000
-        1;-1;100
-        10;-1;-1000
+        -1;3;0
+        0;-1;-1
+        1;-1;-1
+        10;-1;-1
      >
 
     # Parasites cannot earn points in these dimensions
@@ -1036,7 +1036,7 @@ parasite_evolution_phases_3 {
     S:"Phase 3 Reinforcement System Chance"=0.02
 
     # One in X to spawn a Beckon on the Infested Block Residue (random tick). [range: 0 ~ 2147483640, default: 5500]
-    I:"Phase 3 Residue"=0
+    I:"Phase 3 Residue"=15500
 
     # Death bonus value used if parasite_collective_consciousness is enabled. [range: 0 ~ 1000, default: 50]
     I:"Phase 3 Scent Death Bonus"=50
@@ -1123,7 +1123,7 @@ parasite_evolution_phases_4 {
     S:"Phase 4 Reinforcement System Chance"=0.03
 
     # One in X to spawn a Beckon on the Infested Block Residue (random tick). [range: 0 ~ 2147483640, default: 4000]
-    I:"Phase 4 Residue"=0
+    I:"Phase 4 Residue"=7500
 
     # Death bonus value used if parasite_collective_consciousness is enabled. [range: 0 ~ 1000, default: 90]
     I:"Phase 4 Scent Death Bonus"=90
@@ -1219,7 +1219,7 @@ parasite_evolution_phases_5 {
     S:"Phase 5 Reinforcement System Chance"=0.04
 
     # One in X to spawn a Beckon on the Infested Block Residue (random tick). [range: 0 ~ 2147483640, default: 1000]
-    I:"Phase 5 Residue"=0
+    I:"Phase 5 Residue"=5500
 
     # Death bonus value used if parasite_collective_consciousness is enabled. [range: 0 ~ 1000, default: 150]
     I:"Phase 5 Scent Death Bonus"=150
@@ -1315,7 +1315,7 @@ parasite_evolution_phases_6 {
     S:"Phase 6 Reinforcement System Chance"=0.05
 
     # One in X to spawn a Beckon on the Infested Block Residue (random tick). [range: 0 ~ 2147483640, default: 500]
-    I:"Phase 6 Residue"=30000
+    I:"Phase 6 Residue"=5500
 
     # Death bonus value used if parasite_collective_consciousness is enabled. [range: 0 ~ 1000, default: 240]
     I:"Phase 6 Scent Death Bonus"=240
@@ -1406,7 +1406,7 @@ parasite_evolution_phases_7 {
     S:"Phase 7 Reinforcement System Chance"=0.07
 
     # One in X to spawn a Beckon on the Infested Block Residue (random tick). [range: 0 ~ 2147483640, default: 400]
-    I:"Phase 7 Residue"=60000
+    I:"Phase 7 Residue"=5500
 
     # Death bonus value used if parasite_collective_consciousness is enabled. [range: 0 ~ 1000, default: 360]
     I:"Phase 7 Scent Death Bonus"=360
@@ -1491,7 +1491,7 @@ parasite_evolution_phases_8 {
     S:"Phase 8 Reinforcement System Chance"=0.09
 
     # One in X to spawn a Beckon on the Infested Block Residue (random tick). [range: 0 ~ 2147483640, default: 300]
-    I:"Phase 8 Residue"=100000
+    I:"Phase 8 Residue"=5500
 
     # Death bonus value used if parasite_collective_consciousness is enabled. [range: 0 ~ 1000, default: 500]
     I:"Phase 8 Scent Death Bonus"=500
@@ -1813,8 +1813,6 @@ status_effects {
     #  Right click an entity to give it Camouflage. 
     #  [default: [minecraft:golden_apple;0.1;300], [minecraft:golden_carrot;0.03;150]]
     S:"Camouflage Item List" <
-        minecraft:golden_apple;0.1;300
-        minecraft:golden_carrot;0.03;150
      >
 
     # Amount of damage your armor will receive under this effect. [range: 0 ~ 100000, default: 3]


### PR DESCRIPTION
Put the residue into beckons system back because it's not really an issue having adapted parasites make beckons, but I did make it much slower then usual. Made the point count to the point where parasites actually stand a chance at taking over the surface, because -1000 would require having to feed 1000 mobs to the parasites without them being set back in any way. Also I set the phase of the nether to be 3 so people will have to prepare to go there, probably the most questionable thing I've done to the config. Removed the camo stuff because it's entirely pointless.